### PR TITLE
Fix for FIP Groove HLS stream URL

### DIFF
--- a/RadioFrance/Plugin.pm
+++ b/RadioFrance/Plugin.pm
@@ -3707,7 +3707,7 @@ sub toplevel {
 								name	=> 'FIP Groove (HLS)',
 								type	=> 'audio',
 								icon	=> $icons->{fipgroove},
-								url	=> 'https://stream.radiofrance.fr/fipjazz/fipgroove.m3u8',
+								url	=> 'https://stream.radiofrance.fr/fipgroove/fipgroove.m3u8',
 								on_select	=> 'play'
 							},{
 								name	=> 'FIP Groove (AAC)',


### PR DESCRIPTION
There is a little typo in FIP Groove URL for HLS streaming, easy fix :-)